### PR TITLE
support for internal compilation of the plugin

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,6 +1,12 @@
-FRAMAC_SHARE 	:= $(shell frama-c-config -print-share-path)
+ifndef FRAMAC_SHARE
+  FRAMAC_SHARE 	:= $(shell frama-c-config -print-share-path)
+endif
 
-PLUGIN_DIR 	:= src/
+ifeq ("$(PLUGIN_DIR)","")
+PLUGIN_DIR 	:= ./src/
+else
+PLUGIN_DIR      := $(PLUGIN_DIR)/src
+endif
 
 PLUGIN_NAME	:= Pilat
 


### PR DESCRIPTION
In its current incarnation, Pilat's `Makefile` is assuming that is compiled against an already installed version of Frama-C. In order to be able to compile together with the kernel, a few adjustments are needed.

Not that it is currently not very useful, as there is an issue with Frama-C's kernel when compiling internally plugins that have a dependency over an external `cmxa` (`lacaml` for Pilat): Pilat is just serving as a testbed for fixing the issue.