### PR TITLE
Fix 4.09 compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/configure
+/config.status
+/Makefile
+autom4te.cache
+/config.log

--- a/src/pilat_math.mli
+++ b/src/pilat_math.mli
@@ -37,7 +37,7 @@ type n_var =
 
 (** 1. The ring structure *)
 
-module type Ring = sig
+module type Ring_base = sig
   type t
 (* type of elements of the ring *)
 
@@ -54,6 +54,10 @@ module type Ring = sig
   val gt : t -> t -> bool
   val compare : t -> t -> int
   val pp_print : Format.formatter -> t -> unit
+end
+
+module type Ring = sig
+  include Ring_base
   val to_str : t -> string
   val of_str : string -> t
   (** 2. Ast translators : only required for Pilat *)

--- a/src/qring.ml
+++ b/src/qring.ml
@@ -19,14 +19,16 @@
 (*  for more details (enclosed in the file LICENCE).                      *)
 (*                                                                        *)
 (**************************************************************************)
-include Q
-let float_to_t = of_float 
+
+include (Q: Pilat_math.Ring_base with type t = Q.t)
+
+let float_to_t = Q.of_float 
 let approx _ = assert false
-let den f = f |> den |> of_bigint
-let t_to_int = to_int
-let int_to_t = of_int
+let den f = f |> Q.den |> Q.of_bigint
+let t_to_int = Q.to_int
+let int_to_t = Q.of_int
 let t_to_float q = 
-  ((q |> num |> Z.to_float)
+  ((q |> Q.num |> Z.to_float)
   /.
     (q |> Q.den |> Z.to_float))
 
@@ -42,6 +44,6 @@ let deter = t_to_float
 let max = t_to_float
 let min = t_to_float
 
-let to_str = to_string
+let to_str = Q.to_string
 let of_str f = float_to_t (float_of_string f)
 let to_nvars _ = []

--- a/src/qring.mli
+++ b/src/qring.mli
@@ -1,0 +1,1 @@
+include Pilat_math.Ring with type t = Q.t


### PR DESCRIPTION
opam's CI for the new Frama-C 19.1 package made me discover that [Pilat does not compile against 4.09.0](https://ci.ocaml.org/ocaml/opam-repository/pr/14911?test=2%20Revdeps), because the `include Q` in `qring.ml` shadows the standard `=` binary operator (note sure why it worked before, though). This PR gives a proper signature to the part of `Q` `Qring` is actually interested in, making sure the other operations won't interfere with standard ones.