### PR TITLE
compatibility with frama-c 20.0

### DIFF
--- a/src/invar_prover.ml
+++ b/src/invar_prover.ml
@@ -114,7 +114,7 @@ module Make (A : Poly_assign.S with type P.v = Cil_datatype.Varinfo.t
 	let () = Mat_option.feedback "%a : lambda abstractions not supported" 
 	  Printer.pp_term t 
 	in raise Bad_invariant
-      | TCoerce (t,_) | TLogic_coerce (_,t) -> poly_of_term t
+      | TLogic_coerce (_,t) -> poly_of_term t
       | _ -> 
 	let () = Mat_option.feedback "%a term not supported" 
 	  Printer.pp_term t 

--- a/src/main.ml
+++ b/src/main.ml
@@ -60,7 +60,7 @@ let loop_analyzer prj =
           Printer.pp_varinfo v
           Printer.pp_varinfo kf.svar in
 
-      let fundec = Cil.get_fundec self#behavior kf in fundec.slocals <- v :: fundec.slocals
+      let fundec = Visitor_behavior.Get.fundec self#behavior kf in fundec.slocals <- v :: fundec.slocals
 
     method private add_var kf v = 
       Queue.push (fun _ -> self#__add_var kf v)
@@ -139,7 +139,7 @@ let loop_analyzer prj =
           let prj_var_pvar_map = 
             Cil_parser.prj_var_to_pvar 
               varinfos_used 
-              (Cil.get_varinfo self#behavior)
+              (Visitor_behavior.Get.varinfo self#behavior)
           in
           let new_var_set = 
             Assign_type.P.Var.Map.fold
@@ -159,7 +159,7 @@ let loop_analyzer prj =
                    stmt 
                    (Cil_parser.stmt_set b.bstmts)
                    [stmt]
-                   (Cil.get_stmt self#behavior)
+                   (Visitor_behavior.Get.stmt self#behavior)
                 )
 	    with Poly_assign.Not_solvable -> None 
 	  in


### PR DESCRIPTION
This PR will enable compatibility with Frama-C 20.0, but will make the code incompatible with previous versions. I don't know what you prefer, so feel free to close this if you wish.

Note: you can also make a new `pilat` release on opam, to ensure both users of old and new Frama-C versions can install your package.
If so, I would recommend:
- adding a constraint related to the Frama-C version to the `opam` file;
- uploading the opam file to the current release of pilat;
- incorporating this PR, then releasing a new version of pilat, by bumping its version number and updating the Frama-C constraint (>= "20.0").